### PR TITLE
Add more attribute to be masked + fix masking response

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -248,10 +248,7 @@ func removeAuth(header interface{}) interface{} {
 }
 
 func maskField(body interface{}) interface{} {
-	switch v := body.(type) {
-	//this is for request
-	case []byte:
-		bodyByte := v
+	if bodyByte, ok := body.([]byte); ok {
 		bodyMap := make(map[string]interface{}, 0)
 		if err := json.Unmarshal(bodyByte, &bodyMap); err != nil {
 			return string(bodyByte)
@@ -272,29 +269,6 @@ func maskField(body interface{}) interface{} {
 		}
 
 		return bodyMap
-	default:
-		//this is for response
-		data, ok := body.(string)
-		innerData := make(map[string]interface{})
-		if ok {
-			ok := json.Unmarshal([]byte(data), &innerData)
-			if ok == nil {
-				for key, value := range innerData {
-					switch value.(type) {
-					case map[string]interface{}:
-						valueByte, _ := json.Marshal(value)
-						innerData[key] = maskField(valueByte)
-					default:
-						if isSensitiveField(key) {
-							innerData[key] = strings.Repeat("*", 5)
-						} else {
-							innerData[key] = value
-						}
-					}
-				}
-				return innerData
-			}
-		}
 	}
 
 	return body

--- a/logger.go
+++ b/logger.go
@@ -21,12 +21,39 @@ var SENSITIVE_HEADER = []string{
 }
 
 var SENSITIVE_ATTR = map[string]bool{
-	"password":      true,
-	"license":       true,
-	"license_code":  true,
-	"token":         true,
-	"access_token":  true,
-	"refresh_token": true,
+	"password":                 true,
+	"license":                  true,
+	"license_code":             true,
+	"token":                    true,
+	"access_token":             true,
+	"refresh_token":            true,
+	"bank_ac_no":               true, //bank account number
+	"id_number":                true, //id number, equivalent to KTP in Indonesia
+	"mobile":                   true, //mobile number
+	"npwp":                     true, //tax number, equivalent to NPWP in Indonesia
+	"phone":                    true, //phone number
+	"card_no":                  true, //social security number
+	"basic_salary":             true, //basic salary payslip
+	"brutto":                   true, //brutto payslip
+	"employment_deduction":     true, //employment deduction payslip
+	"functional_allowance":     true, //functional allowance payslip
+	"health_allowance":         true, //health allowance payslip
+	"health_deduction":         true, //health deduction payslip
+	"incentive_income_tax_21":  true, //incentive income tax payslip
+	"income_tax_21":            true, //income tax payslip
+	"jht_allowance":            true, //jht allowance payslip
+	"jkk_allowance":            true, //jkk allowance payslilp
+	"jkm_allowance":            true, //jkm allowance payslip
+	"jkn_allowance":            true, //jkn allowance payslip
+	"loan":                     true, //loan payslip
+	"other_deduction":          true, //other deduction payslip
+	"position_allowance":       true, //position allowance payslip
+	"skill_allowance":          true, //skill allowance payslip
+	"special_region_allowance": true, //special region allowance payslip
+	"take_home_pay":            true, //take home pay payslip
+	"total_allowance":          true, //total allowance payslip
+	"total_deduction":          true, //total deduction payslip
+	"total_wages":              true, //total wages payslip
 }
 
 type Log struct {


### PR DESCRIPTION
change log :
- add more attribute to be masked in logger
There is additional attribute to be flagged as a sensitive attribute.

- fix masking responses with sensitive attributes
The response log is not masked although its attribute is flagged as a sensitive attribute (image below shows the value of `refresh_token` and `token` attribute that is already flagged as a sensitive attribute)
![image](https://github.com/runsystemid/golog/assets/7086889/5178ac18-24e9-4a9d-b863-6cf90955977e)

After the fix, the `refresh_token` and `token` attribute's value is masked
![image](https://github.com/runsystemid/golog/assets/7086889/c5cfbcf2-8aee-4d63-801d-4f925047cf68)

It also masks the additional attributes
![image](https://github.com/runsystemid/golog/assets/7086889/78d81f78-08d8-4e55-99a0-a434e486acd2)
