### PR TITLE
adding method info for tdr log

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -202,6 +202,7 @@ func (l *Log) TDR(ctx context.Context, log LogModel) {
 	fields = append(fields, zap.Any("header", removeAuth(log.Header)))
 	fields = append(fields, zap.Any("request", toJSON(maskField(log.Request))))
 	fields = append(fields, zap.String("statusCode", log.StatusCode))
+	fields = append(fields, zap.String("method", log.Method))
 	fields = append(fields, zap.Uint64("httpStatus", log.HttpStatus))
 	fields = append(fields, zap.Any("response", toJSON(maskField(log.Response))))
 	fields = append(fields, zap.Int64("rt", log.ResponseTime.Milliseconds()))

--- a/model.go
+++ b/model.go
@@ -9,6 +9,7 @@ type LogModel struct {
 	IP            string        `json:"ip"`
 	Port          string        `json:"port"`
 	Path          string        `json:"path"`
+	Method        string        `json:"method"`
 	Header        interface{}   `json:"header"`
 	Request       interface{}   `json:"request"`
 	StatusCode    string        `json:"statusCode"`


### PR DESCRIPTION
Because there will be a time when we want to know what method is used for the specific end point, for the sake of clarity i think it always be helpful when we put the info of the method inside the log.

Don't know if it's enough, but you got my point on why i need that *method* info ✌🏿 